### PR TITLE
Setting default headers variable to empty dictionary instead of None 

### DIFF
--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -310,7 +310,7 @@ def _update_resource(ckan_ini_filepath, resource_id, queue, log):
                 return
 
             mimetype = None
-            headers = None
+            headers = {}
             content_type, content_encoding = mimetypes.guess_type(url)
             if content_type:
                 mimetype = _clean_content_type(content_type)


### PR DESCRIPTION
This is required to fix a `NoneType` exception thrown on lines https://github.com/qld-gov-au/ckanext-archiver/blob/master/ckanext/archiver/tasks.py#L788-L789 when the headers variable is initialised as `None` but never set because sometimes a file type cannot be guessed from the method `mimetypes.guess_type(url)` and therefore the `header` variable does not get set inside the if condition statement on line 315.
Initialising the header as an empty dictionary fixes this issue and the code can continue to try alternative methods of finding the file format.

cc. @duttonw @ThrawnCA 