### PR TITLE
[DQL2-6] use the uploader 'metadata' function for uploaded files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
 #    - CKANVERSION=2.7
     -  CKAN_GIT_REPO=ckan/ckan CKANVERSION=2.8
     -  CKAN_GIT_REPO=qld-gov-au/ckan CKAN_BRANCH=qgov-master
-    -  CKAN_GIT_REPO=qld-gov-au/ckan CKAN_BRANCH=updateUploaderForDeleteAndGetFileFunctions
 services:
     - redis-server
     - postgresql

--- a/ckanext/archiver/controller.py
+++ b/ckanext/archiver/controller.py
@@ -55,7 +55,6 @@ class ArchiverController(base.BaseController):
             except Exception:
                 file_name = "resource"
 
-            download_path = os.path.join(relative_archive_path, file_name)
             try:
                 upload = uploader.get_uploader(os.path.join('archive', relative_archive_path))
                 return upload.download(file_name)

--- a/ckanext/archiver/controller.py
+++ b/ckanext/archiver/controller.py
@@ -57,8 +57,8 @@ class ArchiverController(base.BaseController):
 
             download_path = os.path.join(relative_archive_path, file_name)
             try:
-                upload = uploader.get_uploader('archive')
-                return upload.download(download_path)
+                upload = uploader.get_uploader(os.path.join('archive', relative_archive_path))
+                return upload.download(file_name)
             except OSError:
                 # includes FileNotFoundError
                 abort(404, _('Resource data not found'))

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -638,10 +638,12 @@ def archive_resource(context, resource, log, result=None, url_timeout=30):
         cache_url = urlparse.urljoin(config.get('ckan.site_url', ''),
                                      "/dataset/{0}/resource/{1}/archive/{2}".format(
                                          resource['package_id'], resource['id'], file_name))
-        responsePayload = {'cache_filepath': os.path.join(
-            'archive', relative_archive_path, resource['id'], file_name), 'cache_url': cache_url}
+        responsePayload = {
+            'cache_filepath': os.path.join(save_file_folder, file_name),
+            'cache_url': cache_url
+        }
         logging.debug(
-            'file uploaded via Uploader to folder: %s, with filename: %s, responsePayload: %s', relative_archive_path,
+            'file uploaded via Uploader to folder: %s, with filename: %s, responsePayload: %s', save_file_folder,
             file_name, responsePayload)
         return responsePayload
     else:


### PR DESCRIPTION
- this allows us to properly interact with files that are uploaded but stored remotely, eg in S3
- keep using the disk directly as a fallback for plugins that don't implement the metadata function