### PR TITLE
[QOL-7523] don't check for URL changes on uploaded resources with no new file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,9 +12,9 @@ format = pylint
 show_source = True
 
 max-complexity = 10
+max-line-length = 127
 
 # List ignore rules one per line.
 ignore =
-    E501
     C901
     W503

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@
 #based on https://raw.githubusercontent.com/ckan/ckanext-scheming/master/.github/workflows/test.yml
 # alternative https://github.com/ckan/ckan/blob/master/contrib/cookiecutter/ckan_extension/%7B%7Bcookiecutter.project%7D%7D/.github/workflows/test.yml
 name: Tests
-on: [push, pull_request]
+on: [push]
 env:
   CKAN_SQLALCHEMY_URL: postgresql://ckan_default:pass@postgres/ckan_test
   CKAN_DATASTORE_WRITE_URL: postgresql://datastore_write:pass@postgres/datastore_test

--- a/ckanext/archiver/commands.py
+++ b/ckanext/archiver/commands.py
@@ -386,7 +386,8 @@ class Archiver(CkanCommand):
                         not_cached_active += 1
                     else:
                         not_cached_deleted += 1
-                    writer.writerow([resource.id, six.binary_type(resource.extras), "Resource not cached: {0}".format(resource.state)])
+                    writer.writerow([resource.id, six.binary_type(resource.extras),
+                                     "Resource not cached: {0}".format(resource.state)])
                     continue
 
                 # Check that the cached file is there and readable

--- a/ckanext/archiver/plugin.py
+++ b/ckanext/archiver/plugin.py
@@ -123,7 +123,16 @@ class ArchiverPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetForm):
 
         # have any resources' url/format changed?
         for res in package.resources:
-            for key in ('url', 'format'):
+            watched_keys = ['format']
+            # Ignore uploaded resources that aren't being re-uploaded.
+            # Otherwise we'll end up comparing 'example.txt' to
+            # 'http://example.com/dataset/foo/resource/baz/download/example.txt'
+            # and thinking that it's changed.
+            if res.url_type != 'upload' \
+                    or old_resources[res.id]['url_type'] != 'upload' \
+                    or hasattr(res, 'upload'):
+                watched_keys.append('url')
+            for key in watched_keys:
                 old_res_value = old_resources[res.id][key]
                 new_res_value = getattr(res, key)
                 if old_res_value != new_res_value:

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -361,20 +361,17 @@ def _update_resource(ckan_ini_filepath, resource_id, queue, log):
     try:
         download_result = download(context, resource)
         e = {'args': ''}
-    except NotChanged as e:
+    except NotChanged:
         download_status_id = Status.by_text('Content has not changed')
         try_as_api = False
         requires_archive = False
-    except LinkInvalidError as e:
+    except LinkInvalidError:
         download_status_id = Status.by_text('URL invalid')
         try_as_api = False
-    except DownloadException as e:
+    except DownloadException or DownloadError:
         download_status_id = Status.by_text('Download error')
         try_as_api = True
-    except DownloadError as e:
-        download_status_id = Status.by_text('Download error')
-        try_as_api = True
-    except ChooseNotToDownload as e:
+    except ChooseNotToDownload:
         download_status_id = Status.by_text('Chose not to download')
         try_as_api = False
     except Exception as e:
@@ -894,9 +891,9 @@ def requests_wrapper(log, func, *args, **kwargs):
         raise DownloadException(_('Connection error: %s') % e)
     except requests.exceptions.HTTPError as e:
         raise DownloadException(_('Invalid HTTP response: %s') % e)
-    except requests.exceptions.Timeout as e:
+    except requests.exceptions.Timeout:
         raise DownloadException(_('Connection timed out after %ss') % kwargs.get('timeout', '?'))
-    except requests.exceptions.TooManyRedirects as e:
+    except requests.exceptions.TooManyRedirects:
         raise DownloadException(_('Too many redirects'))
     except requests.exceptions.RequestException as e:
         raise DownloadException(_('Error downloading: %s') % e)
@@ -1043,9 +1040,9 @@ def link_checker(context, data):
         raise LinkHeadRequestError(_('Connection error: %s') % e)
     except requests.exceptions.HTTPError as e:
         raise LinkHeadRequestError(_('Invalid HTTP response: %s') % e)
-    except requests.exceptions.Timeout as e:
+    except requests.exceptions.Timeout:
         raise LinkHeadRequestError(_('Connection timed out after %ss') % url_timeout)
-    except requests.exceptions.TooManyRedirects as e:
+    except requests.exceptions.TooManyRedirects:
         raise LinkHeadRequestError(_('Too many redirects'))
     except requests.exceptions.RequestException as e:
         raise LinkHeadRequestError(_('Error during request: %s') % e)

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -365,13 +365,13 @@ def _update_resource(ckan_ini_filepath, resource_id, queue, log):
         download_status_id = Status.by_text('Content has not changed')
         try_as_api = False
         requires_archive = False
-    except LinkInvalidError:
+    except LinkInvalidError as e:
         download_status_id = Status.by_text('URL invalid')
         try_as_api = False
-    except DownloadException or DownloadError:
+    except (DownloadException, DownloadError) as e:
         download_status_id = Status.by_text('Download error')
         try_as_api = True
-    except ChooseNotToDownload:
+    except ChooseNotToDownload as e:
         download_status_id = Status.by_text('Chose not to download')
         try_as_api = False
     except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -60,10 +60,10 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
 
     install_requires=[
-      # CKAN extensions should not list dependencies here, but in a separate
-      # ``requirements.txt`` file.
-      #
-      # http://docs.ckan.org/en/latest/extensions/best-practices.html#add-third-party-libraries-to-requirements-txt
+        # CKAN extensions should not list dependencies here, but in a separate
+        # ``requirements.txt`` file.
+        #
+        # http://docs.ckan.org/en/latest/extensions/best-practices.html#add-third-party-libraries-to-requirements-txt
     ],
 
     # If there are data files included in your packages that need to be

--- a/tests/test_archiver.py
+++ b/tests/test_archiver.py
@@ -199,7 +199,7 @@ class TestArchiver(BaseCase):
     def _test_package(self, url, format=None):
         pkg = {'resources': [
             {'url': url, 'format': format or 'TXT', 'description': 'Test'}
-            ]}
+        ]}
         pkg = ckan_factories.Dataset(**pkg)
         return pkg
 
@@ -437,7 +437,7 @@ class TestDownload(BaseCase):
         context = {'model': model, 'ignore_auth': True, 'session': model.Session, 'user': 'test'}
         pkg = {'name': 'testpkg', 'resources': [
             {'url': url, 'format': format or 'TXT', 'description': 'Test'}
-            ]}
+        ]}
         pkg = get_action('package_create')(context, pkg)
         return pkg['resources'][0]
 


### PR DESCRIPTION
This avoids false positives from comparing plain filenames ('example.txt')
with full download URLs ('http://example.com/dataset/foo/resource/baz/download/example.txt')