### PR TITLE
Develop to master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 ---
 name: Tests
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
 env:
   CKAN_SQLALCHEMY_URL: postgresql://ckan_default:pass@postgres/ckan_test
   CKAN_DATASTORE_WRITE_URL: postgresql://datastore_write:pass@postgres/datastore_test

--- a/ckanext/archiver/cli/__init__.py
+++ b/ckanext/archiver/cli/__init__.py
@@ -56,8 +56,6 @@ class ArchivalCommands():
 
     def update_test(self, dataset_spec, queue=None):
         from ckanext.archiver import tasks
-        # Prevent it loading config again
-        tasks.load_config = lambda x: None
         log = logging.getLogger('ckanext.archiver')
         for pkg_or_res, is_pkg, num_resources_for_pkg, pkg_for_res in \
                 self._get_packages_and_resources_in_args(dataset_spec):

--- a/ckanext/archiver/controller/__init__.py
+++ b/ckanext/archiver/controller/__init__.py
@@ -20,7 +20,7 @@ def archive_download(id, resource_id, filename=None):
     try:
         resource = toolkit.get_action('resource_show')(context, {'id': resource_id})
         # Quick auth check to ensure you can access this resource
-        toolkit.check_access('package_show')(context, {'id': id})
+        toolkit.check_access('package_show', context, {'id': id})
     except (toolkit.ObjectNotFound, toolkit.NotAuthorized):
         toolkit.abort(404, _('Resource not found'))
 

--- a/ckanext/archiver/lib.py
+++ b/ckanext/archiver/lib.py
@@ -10,7 +10,7 @@ from ckanext.archiver.tasks import update_package, update_resource
 log = logging.getLogger(__name__)
 
 
-def compat_enqueue(name, fn, queue, args=None, kwargs=None):
+def compat_enqueue(name, fn, queue, args=[], kwargs={}):
     u'''
     Enqueue a background job using Celery or RQ.
     '''
@@ -33,14 +33,14 @@ def create_archiver_resource_task(resource, queue):
     else:
         package = resource.package
 
-    compat_enqueue('archiver.update_resource', update_resource, queue, None, {'resource_id': resource.id})
+    compat_enqueue('archiver.update_resource', update_resource, queue, kwargs={'resource_id': resource.id})
 
     log.debug('Archival of resource put into queue %s: %s/%s url=%r',
               queue, package.name, resource.id, resource.url)
 
 
 def create_archiver_package_task(package, queue):
-    compat_enqueue('archiver.update_package', update_package, queue, None, {'package_id': package.id})
+    compat_enqueue('archiver.update_package', update_package, queue, kwargs={'package_id': package.id})
 
     log.debug('Archival of package put into queue %s: %s',
               queue, package.name)

--- a/ckanext/archiver/lib.py
+++ b/ckanext/archiver/lib.py
@@ -1,11 +1,9 @@
 # encoding: utf-8
 
 import logging
-import os
 import six
 
 import ckan.plugins as p
-from ckan.plugins.toolkit import config
 
 from ckanext.archiver.tasks import update_package, update_resource
 
@@ -33,18 +31,15 @@ def create_archiver_resource_task(resource, queue):
         package = resource.resource_group.package
     else:
         package = resource.package
-    ckan_ini_filepath = os.path.abspath(config['__file__'])
 
-    compat_enqueue('archiver.update_resource', update_resource, queue, [ckan_ini_filepath, resource.id])
+    compat_enqueue('archiver.update_resource', update_resource, queue, [resource.id])
 
     log.debug('Archival of resource put into queue %s: %s/%s url=%r',
               queue, package.name, resource.id, resource.url)
 
 
 def create_archiver_package_task(package, queue):
-    ckan_ini_filepath = os.path.abspath(config['__file__'])
-
-    compat_enqueue('archiver.update_package', update_package, queue, [ckan_ini_filepath, package.id])
+    compat_enqueue('archiver.update_package', update_package, queue, [package.id])
 
     log.debug('Archival of package put into queue %s: %s',
               queue, package.name)

--- a/ckanext/archiver/lib.py
+++ b/ckanext/archiver/lib.py
@@ -10,14 +10,14 @@ from ckanext.archiver.tasks import update_package, update_resource
 log = logging.getLogger(__name__)
 
 
-def compat_enqueue(name, fn, queue, args=None):
+def compat_enqueue(name, fn, queue, args=None, kwargs=None):
     u'''
     Enqueue a background job using Celery or RQ.
     '''
     try:
         # Try to use RQ
         from ckan.plugins.toolkit import enqueue_job
-        enqueue_job(fn, args=args, queue=queue)
+        enqueue_job(fn, args=args, kwargs=kwargs, queue=queue)
     except ImportError:
         # Fallback to Celery
         import uuid
@@ -32,14 +32,14 @@ def create_archiver_resource_task(resource, queue):
     else:
         package = resource.package
 
-    compat_enqueue('archiver.update_resource', update_resource, queue, [resource.id])
+    compat_enqueue('archiver.update_resource', update_resource, queue, None, {'resource_id': resource.id})
 
     log.debug('Archival of resource put into queue %s: %s/%s url=%r',
               queue, package.name, resource.id, resource.url)
 
 
 def create_archiver_package_task(package, queue):
-    compat_enqueue('archiver.update_package', update_package, queue, [package.id])
+    compat_enqueue('archiver.update_package', update_package, queue, None, {'package_id': package.id})
 
     log.debug('Archival of package put into queue %s: %s',
               queue, package.name)

--- a/ckanext/archiver/model.py
+++ b/ckanext/archiver/model.py
@@ -81,6 +81,12 @@ broken_enum = {True: 'Broken',
                False: 'Downloaded OK'}
 
 
+def _get_status_by_id(status_id):
+    if status_id is None:
+        return None
+    return Status.by_id(status_id)
+
+
 class Archival(Base):
     """
     Details of the archival of resources. Has the filepath for successfully
@@ -161,9 +167,7 @@ class Archival(Base):
 
     @property
     def status(self):
-        if self.status_id is None:
-            return None
-        return Status.by_id(self.status_id)
+        return _get_status_by_id(self.status_id)
 
     def as_dict(self):
         context = {'model': model}
@@ -196,7 +200,7 @@ def aggregate_archivals_for_a_dataset(archivals):
             archival_dict['reason'] = archival.reason
 
     if archivals:
-        archival_dict['status'] = Status.by_id(archival_dict['status_id'])
+        archival_dict['status'] = _get_status_by_id(archival_dict['status_id'])
         archival_dict['is_broken'] = \
             Status.is_status_broken(archival_dict['status_id'])
     return archival_dict

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -111,7 +111,7 @@ class CkanError(ArchiverError):
     pass
 
 
-def update_resource(resource_id, queue='bulk'):
+def update_resource(ckan_ini_filepath=None, resource_id=None, queue='bulk'):
     '''
     Archive a resource.
     '''
@@ -135,7 +135,7 @@ def update_resource(resource_id, queue='bulk'):
         raise
 
 
-def update_package(package_id, queue='bulk'):
+def update_package(ckan_ini_filepath=None, package_id=None, queue='bulk'):
     '''
     Archive a package.
     '''

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -58,17 +58,6 @@ if toolkit.check_ckan_version(max_version='2.6.99'):
         link_checker(*args, **kwargs)
 
 
-def load_config(ckan_ini_filepath):
-    if ckan_ini_filepath:
-        toolkit.load_config(ckan_ini_filepath)
-
-    # give routes enough information to run url_for
-    parsed = urlparse.urlparse(config.get('ckan.site_url', 'http://0.0.0.0'))
-    request_config = routes.request_config()
-    request_config.host = parsed.netloc + parsed.path
-    request_config.protocol = parsed.scheme
-
-
 class ArchiverError(Exception):
     pass
 
@@ -127,8 +116,6 @@ def update_resource(ckan_ini_filepath, resource_id, queue='bulk'):
     '''
     Archive a resource.
     '''
-    load_config(ckan_ini_filepath)
-
     log.info('Starting update_resource task: res_id=%r queue=%s', resource_id, queue)
 
     # HACK because of race condition #1481
@@ -153,8 +140,6 @@ def update_package(ckan_ini_filepath, package_id, queue='bulk'):
     '''
     Archive a package.
     '''
-    load_config(ckan_ini_filepath)
-
     log.info('Starting update_package task: package_id=%r queue=%s',
              package_id, queue)
 
@@ -239,8 +224,6 @@ def _update_resource(ckan_ini_filepath, resource_id, queue, log):
         }
     If not successful, returns None.
     """
-    load_config(ckan_ini_filepath)
-
     from ckan import model
     from ckanext.archiver.model import Status, Archival
 

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -111,7 +111,7 @@ class CkanError(ArchiverError):
     pass
 
 
-def update_resource(ckan_ini_filepath, resource_id, queue='bulk'):
+def update_resource(resource_id, queue='bulk'):
     '''
     Archive a resource.
     '''
@@ -124,7 +124,7 @@ def update_resource(ckan_ini_filepath, resource_id, queue='bulk'):
     # Also put try/except around it is easier to monitor ckan's log rather than
     # celery's task status.
     try:
-        result = _update_resource(ckan_ini_filepath, resource_id, queue, log)
+        result = _update_resource(resource_id, queue, log)
         return result
     except Exception as e:
         if os.environ.get('DEBUG'):
@@ -135,7 +135,7 @@ def update_resource(ckan_ini_filepath, resource_id, queue='bulk'):
         raise
 
 
-def update_package(ckan_ini_filepath, package_id, queue='bulk'):
+def update_package(package_id, queue='bulk'):
     '''
     Archive a package.
     '''
@@ -146,7 +146,7 @@ def update_package(ckan_ini_filepath, package_id, queue='bulk'):
     # Also put try/except around it is easier to monitor ckan's log rather than
     # celery's task status.
     try:
-        _update_package(ckan_ini_filepath, package_id, queue, log)
+        _update_package(package_id, queue, log)
     except Exception as e:
         if os.environ.get('DEBUG'):
             raise
@@ -157,7 +157,7 @@ def update_package(ckan_ini_filepath, package_id, queue='bulk'):
         raise
 
 
-def _update_package(ckan_ini_filepath, package_id, queue, log):
+def _update_package(package_id, queue, log):
     from ckan import model
 
     get_action = toolkit.get_action
@@ -168,7 +168,7 @@ def _update_package(ckan_ini_filepath, package_id, queue, log):
 
     for resource in package['resources']:
         resource_id = resource['id']
-        res = _update_resource(ckan_ini_filepath, resource_id, queue, log)
+        res = _update_resource(resource_id, queue, log)
         if res:
             num_archived += 1
 
@@ -201,7 +201,7 @@ def _update_search_index(package_id, log):
     log.info('Search indexed %s', package['name'])
 
 
-def _update_resource(ckan_ini_filepath, resource_id, queue, log):
+def _update_resource(resource_id, queue, log):
     """
     Link check and archive the given resource.
     If successful, updates the archival table with the cache_url & hash etc.

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -7,7 +7,6 @@ import json
 import mimetypes
 import os
 import requests
-import routes
 import shutil
 from six.moves.urllib import parse as urlparse
 import six

--- a/tests/test_archiver.py
+++ b/tests/test_archiver.py
@@ -212,13 +212,13 @@ class TestArchiver():
 
     def test_file_url(self):
         res_id = self._test_resource('file:///home/root/test.txt')['id']  # scheme not allowed
-        result = update_resource(res_id)
+        result = update_resource(resource_id=res_id)
         assert not result, result
         self.assert_archival_error('Invalid url scheme', res_id)
 
     def test_bad_url(self):
         res_id = self._test_resource('http:host.com')['id']  # no slashes
-        result = update_resource(res_id)
+        result = update_resource(resource_id=res_id)
         assert not result, result
         self.assert_archival_error('URL parsing failure', res_id)
 
@@ -289,21 +289,21 @@ class TestArchiver():
     def test_update_with_zero_length(self, url=None):
         # i.e. no content
         res_id = self._test_resource(url)['id']
-        result = update_resource(res_id)
+        result = update_resource(resource_id=res_id)
         assert not result, result
         self.assert_archival_error('Content-length after streaming was 0', res_id)
 
     @with_mock_url('?status=404&content=test&content-type=csv')
     def test_file_not_found(self, url=None):
         res_id = self._test_resource(url)['id']
-        result = update_resource(res_id)
+        result = update_resource(resource_id=res_id)
         assert not result, result
         self.assert_archival_error('Server reported status error: 404 Not Found', res_id)
 
     @with_mock_url('?status=500&content=test&content-type=csv')
     def test_server_error(self, url=None):
         res_id = self._test_resource(url)['id']
-        result = update_resource(res_id)
+        result = update_resource(resource_id=res_id)
         assert not result, result
         self.assert_archival_error('Server reported status error: 500 Internal Server Error', res_id)
 
@@ -311,7 +311,7 @@ class TestArchiver():
     def test_file_too_large_1(self, url=None):
         # will stop after receiving the header
         res_id = self._test_resource(url)['id']
-        result = update_resource(res_id)
+        result = update_resource(resource_id=res_id)
         assert not result, result
         self.assert_archival_error('Content-length 1000001 exceeds maximum allowed value 1000000', res_id)
 
@@ -319,7 +319,7 @@ class TestArchiver():
     def test_file_too_large_2(self, url=None):
         # no size info in headers - it stops only after downloading the content
         res_id = self._test_resource(url)['id']
-        result = update_resource(res_id)
+        result = update_resource(resource_id=res_id)
         assert not result, result
         self.assert_archival_error('Content-length 1000001 exceeds maximum allowed value 1000000', res_id)
 
@@ -353,7 +353,7 @@ class TestArchiver():
 
         res_id = self._test_resource(url)['id']
 
-        update_resource(res_id, 'queue1')
+        update_resource(resource_id=res_id, queue='queue1')
 
         assert len(testipipe.calls) == 1
 
@@ -387,7 +387,7 @@ class TestArchiver():
 
         pkg = self._test_package(url)
 
-        update_package(pkg['id'], 'queue1')
+        update_package(package_id=pkg['id'], queue='queue1')
 
         assert len(testipipe.calls) == 2, len(testipipe.calls)
 
@@ -404,7 +404,7 @@ class TestArchiver():
         assert params.get('resource_id') is None
 
     def _get_update_resource_json(self, id):
-        result = update_resource(id)
+        result = update_resource(resource_id=id)
         assert result, "update_resource returned: {}".format(result)
         return json.loads(result)
 

--- a/tests/test_archiver.py
+++ b/tests/test_archiver.py
@@ -212,13 +212,13 @@ class TestArchiver():
 
     def test_file_url(self):
         res_id = self._test_resource('file:///home/root/test.txt')['id']  # scheme not allowed
-        result = update_resource(None, res_id)
+        result = update_resource(res_id)
         assert not result, result
         self.assert_archival_error('Invalid url scheme', res_id)
 
     def test_bad_url(self):
         res_id = self._test_resource('http:host.com')['id']  # no slashes
-        result = update_resource(None, res_id)
+        result = update_resource(res_id)
         assert not result, result
         self.assert_archival_error('URL parsing failure', res_id)
 
@@ -289,21 +289,21 @@ class TestArchiver():
     def test_update_with_zero_length(self, url=None):
         # i.e. no content
         res_id = self._test_resource(url)['id']
-        result = update_resource(None, res_id)
+        result = update_resource(res_id)
         assert not result, result
         self.assert_archival_error('Content-length after streaming was 0', res_id)
 
     @with_mock_url('?status=404&content=test&content-type=csv')
     def test_file_not_found(self, url=None):
         res_id = self._test_resource(url)['id']
-        result = update_resource(None, res_id)
+        result = update_resource(res_id)
         assert not result, result
         self.assert_archival_error('Server reported status error: 404 Not Found', res_id)
 
     @with_mock_url('?status=500&content=test&content-type=csv')
     def test_server_error(self, url=None):
         res_id = self._test_resource(url)['id']
-        result = update_resource(None, res_id)
+        result = update_resource(res_id)
         assert not result, result
         self.assert_archival_error('Server reported status error: 500 Internal Server Error', res_id)
 
@@ -311,7 +311,7 @@ class TestArchiver():
     def test_file_too_large_1(self, url=None):
         # will stop after receiving the header
         res_id = self._test_resource(url)['id']
-        result = update_resource(None, res_id)
+        result = update_resource(res_id)
         assert not result, result
         self.assert_archival_error('Content-length 1000001 exceeds maximum allowed value 1000000', res_id)
 
@@ -319,7 +319,7 @@ class TestArchiver():
     def test_file_too_large_2(self, url=None):
         # no size info in headers - it stops only after downloading the content
         res_id = self._test_resource(url)['id']
-        result = update_resource(None, res_id)
+        result = update_resource(res_id)
         assert not result, result
         self.assert_archival_error('Content-length 1000001 exceeds maximum allowed value 1000000', res_id)
 
@@ -353,7 +353,7 @@ class TestArchiver():
 
         res_id = self._test_resource(url)['id']
 
-        update_resource(None, res_id, 'queue1')
+        update_resource(res_id, 'queue1')
 
         assert len(testipipe.calls) == 1
 
@@ -387,7 +387,7 @@ class TestArchiver():
 
         pkg = self._test_package(url)
 
-        update_package(None, pkg['id'], 'queue1')
+        update_package(pkg['id'], 'queue1')
 
         assert len(testipipe.calls) == 2, len(testipipe.calls)
 
@@ -404,7 +404,7 @@ class TestArchiver():
         assert params.get('resource_id') is None
 
     def _get_update_resource_json(self, id):
-        result = update_resource(None, id)
+        result = update_resource(id)
         assert result, "update_resource returned: {}".format(result)
         return json.loads(result)
 


### PR DESCRIPTION
- Fix incorrect `check_access` syntax
- Drop config reloading that is unnecessary and interfering with task execution.
- Handle missing `status_id` more robustly.