### PR TITLE
QOL-9055 Prepare for Python 3

### DIFF
--- a/ckanext/archiver/controller/__init__.py
+++ b/ckanext/archiver/controller/__init__.py
@@ -22,7 +22,7 @@ def archive_download(id, resource_id, filename=None):
         # Quick auth check to ensure you can access this resource
         toolkit.check_access('package_show', context, {'id': id})
     except (toolkit.ObjectNotFound, toolkit.NotAuthorized):
-        toolkit.abort(404, _('Resource not found'))
+        return toolkit.abort(404, _('Resource not found'))
 
     # Archived files are only links not uploads
     if resource.get('url_type') != 'upload':
@@ -50,5 +50,5 @@ def archive_download(id, resource_id, filename=None):
             return upload.download(file_name)
         except OSError:
             # includes FileNotFoundError
-            toolkit.abort(404, _('Resource data not found'))
-    toolkit.abort(404, _('No download is available'))
+            return toolkit.abort(404, _('Resource data not found'))
+    return toolkit.abort(404, _('No download is available'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-celery==3.1.25
+# Install Celery if you are running CKAN 2.6 or less
+#celery==3.1.25
 kombu==3.0.37
 progressbar2==3.55.0
 #SQLAlchemy>=0.6.6

--- a/tests/mock_remote_server.py
+++ b/tests/mock_remote_server.py
@@ -6,17 +6,12 @@ from contextlib import contextmanager
 from threading import Thread
 from time import sleep
 from wsgiref.simple_server import make_server
-from six.moves.urllib import parse as urllib2
 import six
+from six.moves import reduce
+from six.moves.http_client import responses
+from six.moves.urllib.request import urlopen
 import socket
 import os
-
-try:
-    # Python 2
-    from httplib import responses
-except ImportError:
-    # Python 3
-    from http.client import responses
 
 
 def _get_str_params(request):
@@ -38,7 +33,7 @@ class MockHTTPServer(object):
     a separate thread, eg::
 
         >>> with MockTestServer().serve() as server_address:
-        ...     urllib2.urlopen(server_address)
+        ...     urlopen(server_address)
         ...
 
     Subclass this and override __call__ to provide your own WSGI handler function.
@@ -56,7 +51,7 @@ class MockHTTPServer(object):
         This uses context manager to make sure the server is stopped::
 
             >>> with MockTestServer().serve() as addr:
-            ...     print(urllib2.urlopen('%s/?content=hello+world').read())
+            ...     print(urlopen('%s/?content=hello+world').read())
             ...
             'hello world'
         """
@@ -87,7 +82,7 @@ class MockHTTPServer(object):
             # call completes. Set a very small timeout as we don't actually need to
             # wait for a response. We don't care about exceptions here either.
             try:
-                urllib2.urlopen("http://%s:%s/" % (host, port), timeout=0.01)
+                urlopen("http://%s:%s/" % (host, port), timeout=0.01)
             except Exception:
                 pass
 
@@ -99,8 +94,8 @@ class MockHTTPServer(object):
         called and its return value used.
         """
         modpath, var = varspec.split(':')
-        mod = six.moves.reduce(getattr, modpath.split('.')[1:], __import__(modpath))
-        var = six.moves.reduce(getattr, var.split('.'), mod)
+        mod = reduce(getattr, modpath.split('.')[1:], __import__(modpath))
+        var = reduce(getattr, var.split('.'), mod)
         try:
             return six.ensure_binary(var())
         except TypeError:


### PR DESCRIPTION
- Ensure views are returned to Flask
- Increase use of 'six' for compatibility
- Drop obsolete Celery dependency