### PR TITLE
Develop to master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # Install Celery if you are running CKAN 2.6 or less
 #celery==3.1.25
-kombu==3.0.37
 progressbar2==3.55.0
 #SQLAlchemy>=0.6.6
 #requests>=1.1.0


### PR DESCRIPTION
Drop obsolete 'kombu' dependency (only needed for Celery).