### PR TITLE
QOL-9055 fix bugs on Python 3

### DIFF
--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -593,7 +593,7 @@ def archive_resource(context, resource, log, result=None, url_timeout=30):
         from werkzeug.datastructures import FileStorage as FlaskFileStorage
         # we use the Upload class to push to our preferred filestorage solution
         toUpload = {"fileStorage": FlaskFileStorage(
-            filename=file_name, stream=open(result['saved_file']), content_type=result['mimetype']),
+            filename=file_name, stream=open(result['saved_file'], 'rb'), content_type=result['mimetype']),
             "preserve_filename": True}
         upload = uploader.get_uploader(save_file_folder)
         upload.update_data_dict(toUpload, 'url_field', 'fileStorage', 'clear_field')

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -582,7 +582,7 @@ def archive_resource(context, resource, log, result=None, url_timeout=30):
         file_name = parsed_url.path.split('/')[-1] or 'resource'
         file_name = file_name.strip()  # trailing spaces cause problems
         file_name = file_name.encode('ascii', 'ignore')  # e.g. u'\xa3' signs
-        file_name = str(file_name)
+        file_name = six.ensure_text(file_name)
     except Exception:
         file_name = "resource"
 
@@ -633,7 +633,7 @@ def archive_resource(context, resource, log, result=None, url_timeout=30):
                         'ckanext-archiver.cache_url_root in config')
             raise ArchiveError(_('No value for ckanext-archiver.cache_url_root in config'))
         cache_url = urljoin(str(context['cache_url_root']),
-                            '%s/%s' % (str(relative_archive_path), str(file_name)))
+                            '%s/%s' % (relative_archive_path, file_name))
         return {'cache_filepath': saved_file,
                 'cache_url': cache_url}
 


### PR DESCRIPTION
- Use 'six' to fix string typing
- Ensure files are downloaded in binary mode since they might not be text.