### PR TITLE
[QOLDEV-329] fix file permissions on archive cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: '3.6'
+          python-version: '3.x'
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -12,6 +12,7 @@ import six
 from six import text_type as str
 from six.moves import http_client
 from six.moves.urllib.parse import urlparse, urljoin, quote, urlunparse
+import stat
 import tempfile
 from time import sleep
 
@@ -621,7 +622,7 @@ def archive_resource(context, resource, log, result=None, url_timeout=30):
         shutil.move(result['saved_file'], saved_file)
         log.info('Going to do chmod: %s', saved_file)
         try:
-            os.chmod(saved_file, 644)  # allow other users to read it
+            os.chmod(saved_file, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)  # allow other users to read it
         except Exception as e:
             log.error('chmod failed %s: %s', saved_file, e)
             raise


### PR DESCRIPTION
- Was incorrectly using an int literal when it should be octal. Replace with bitwise assembly from official flags.