### PR TITLE
[QOLDEV-987] fix OrderedDict import

### DIFF
--- a/ckanext/archiver/reports.py
+++ b/ckanext/archiver/reports.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import copy
-from sqlalchemy.util import OrderedDict
+from collections import OrderedDict
 
 from ckan.common import _
 import ckan.model as model

--- a/ckanext/archiver/utils.py
+++ b/ckanext/archiver/utils.py
@@ -7,7 +7,7 @@ import shutil
 import six
 from six.moves.urllib.parse import urlparse
 from sqlalchemy import func
-from sqlalchemy.util import OrderedDict
+from collections import OrderedDict
 import sys
 from time import sleep
 


### PR DESCRIPTION
- Use the standard 'collections' import as we now assume we're on a new enough Python version. Previous commit mistakenly switched it to the pre-2.7 import.